### PR TITLE
fix: specify the correct path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "blindpay",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Node.js library for the BlindPay API",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && tsc",
     "dev": "tsc --watch --project tsconfig.json",


### PR DESCRIPTION
the sdk is not specifying the correct path to the files (all of them are under the src folder).

also, i would recommend adding `dist` to the .gitignore

also², why do i've to pass each non-required variable as null?
<img width="679" alt="image" src="https://github.com/user-attachments/assets/eee9caef-970b-4e8b-aa1f-20ef700e9ed9" />