### PR TITLE
fix: redundant assignment to readonly param

### DIFF
--- a/src/blindpay.ts
+++ b/src/blindpay.ts
@@ -41,7 +41,6 @@ export class Blindpay {
     }
 
     this.baseUrl = baseUrl || defaultBaseUrl;
-    this.instanceId = instanceId;
 
     this.headers = new Headers({
       Authorization: `Bearer ${this.key}`,


### PR DESCRIPTION
`instanceId` is already a class prop via the constructor. no need to assign it again - removed the extra line.
