### PR TITLE
fix: correct BankAccountType typo

### DIFF
--- a/.changeset/tiny-foxes-jump.md
+++ b/.changeset/tiny-foxes-jump.md
@@ -1,0 +1,6 @@
+---
+"@blindpay/node": patch
+---
+
+Fix BankAccountType typo: changed "savings" to "saving" to match API response
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blindpay/node",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "description": "Official Node.js SDK for Blindpay API - Global payments infrastructure",
     "keywords": [
         "blindpay",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,7 +22,7 @@ export type StablecoinToken = "USDC" | "USDT" | "USDB"
 
 export type TransactionDocumentType = "invoice" | "purchase_order" | "delivery_slip" | "contract" | "customs_declaration" | "bill_of_lading" | "others";
 
-export type BankAccountType = "checking" | "savings";
+export type BankAccountType = "checking" | "saving";
 
 export type Currency = "USDC" | "USDT" | "USDB" | "BRL" | "USD" | "MXN" | "COP" | "ARS";
 


### PR DESCRIPTION
## Summary

Fixes a typo in the `BankAccountType` type definition.

### Changes

- Changed `"savings"` to `"saving"` to match the actual API response

### Type

This is a patch version bump.