### PR TITLE
fix: correct SourceOfFundsDocType values to match API spec

### DIFF
--- a/.changeset/fix-source-of-funds.md
+++ b/.changeset/fix-source-of-funds.md
@@ -1,0 +1,5 @@
+---
+"@blindpay/node": patch
+---
+
+Fix SourceOfFundsDocType enum values to match API spec

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -581,16 +581,16 @@ export type PurposeOfTransactions =
 
 export type SourceOfFundsDocType =
     | "business_income"
+    | "esops"
     | "gambling_proceeds"
     | "gifts"
     | "government_benefits"
     | "inheritance"
-    | "investment_income"
-    | "legal_settlements"
-    | "loan_proceeds"
-    | "pension_or_retirement"
-    | "property_sale"
-    | "salary_wages"
+    | "investment_loans"
+    | "investment_proceeds"
+    | "pension_retirement"
+    | "salary"
+    | "sale_of_assets_real_estate"
     | "savings"
     | "someone_else_funds";
 


### PR DESCRIPTION
Fixes wrong enum values and adds missing ones (esops, investment_proceeds).