### PR TITLE
fix: complete API sync — fix typo and add missing fields

### DIFF
--- a/.changeset/fix-api-sync.md
+++ b/.changeset/fix-api-sync.md
@@ -1,0 +1,5 @@
+---
+"@blindpay/node": patch
+---
+
+Fix receiver_invite_redirect_url typo, add missing fields

--- a/src/resources/instances/index.ts
+++ b/src/resources/instances/index.ts
@@ -23,7 +23,8 @@ export type GetInstanceMembersResponse = Array<{
 
 export type UpdateInstanceInput = {
     name: string;
-    receiver_invite_redirect_urL?: string;
+    receiver_invite_redirect_url?: string;
+    email_notifications?: boolean;
     require_passkey?: boolean;
 };
 

--- a/src/resources/payins/index.ts
+++ b/src/resources/payins/index.ts
@@ -71,6 +71,7 @@ export type Payin = {
     blindpay_quotation: number;
     currency: Extract<Currency, "BRL" | "USD" | "MXN" | "COP" | "ARS">;
     billing_fee?: number | null;
+    billing_fee_amount?: string | null;
     is_otc?: boolean | null;
     payer_rules?: PayerRules | null;
     name: string;

--- a/src/resources/payins/quotes.ts
+++ b/src/resources/payins/quotes.ts
@@ -18,6 +18,7 @@ export type CreatePayinQuoteInput = {
     cover_fees: boolean;
     partner_fee_id: string | null;
     payer_rules?: PayerRules | null;
+    wallet_id?: string;
 };
 
 export type CreatePayinQuoteResponse = {

--- a/src/resources/payouts/index.ts
+++ b/src/resources/payouts/index.ts
@@ -85,6 +85,8 @@ export type Payout = {
     transfers_account?: string;
     transfers_type: "CVU" | "CBU" | "ALIAS";
     has_virtual_account: boolean;
+    billing_fee_amount?: string | null;
+    jpm_track_data?: Record<string, unknown> | string | null;
 };
 
 export type ListPayoutsInput = PaginationParams & {


### PR DESCRIPTION
Fixes receiver_invite_redirect_urL typo, adds missing fields to instance update, payin quote, payin response, payout response.

## Changes

- **Fix typo**: `receiver_invite_redirect_urL` -> `receiver_invite_redirect_url` in `UpdateInstanceInput`
- **UpdateInstanceInput**: add `email_notifications` (optional boolean)
- **CreatePayinQuoteInput**: add `wallet_id` (optional string)
- **Payin response**: add `billing_fee_amount` (optional string)
- **Payout response**: add `billing_fee_amount` (optional string), `jpm_track_data` (optional object/string)