### PR TITLE
fix: add missing transfer fields to sync with API

### DIFF
--- a/.changeset/fix-transfers.md
+++ b/.changeset/fix-transfers.md
@@ -1,0 +1,5 @@
+---
+"@blindpay/node": patch
+---
+
+Add missing transfer response fields (receiver_id, address, network, quote response fields)

--- a/src/resources/transfers/index.ts
+++ b/src/resources/transfers/index.ts
@@ -48,6 +48,9 @@ export type Transfer = {
     receiver_token: StablecoinToken;
     receiver_wallet_address: string;
     partner_fee_amount: number | null;
+    receiver_id: string;
+    address: string;
+    network: Network;
 };
 
 export type CreateTransferQuoteInput = {
@@ -57,16 +60,16 @@ export type CreateTransferQuoteInput = {
     receiver_token: StablecoinToken;
     receiver_network: Network;
     request_amount: number;
-    cover_fees: boolean;
+    cover_fees?: boolean | null;
     amount_reference: "sender" | "receiver";
     partner_fee_id?: string | null;
 };
 
 export type CreateTransferQuoteResponse = {
     id: string;
-    expires_at: number;
-    commercial_quotation: number;
-    blindpay_quotation: number;
+    expires_at: number | null;
+    commercial_quotation: number | null;
+    blindpay_quotation: number | null;
     receiver_amount: number;
     sender_amount: number;
     partner_fee_amount: number | null;

--- a/src/resources/transfers/transfers.test.ts
+++ b/src/resources/transfers/transfers.test.ts
@@ -44,6 +44,9 @@ const mockTransfer: Transfer = {
     receiver_token: "USDC",
     receiver_wallet_address: "0xDD6a3aD0949396e57C7738ba8FC1A46A5a1C372C",
     partner_fee_amount: null,
+    receiver_id: "re_000000000000",
+    address: "0xDD6a3aD0949396e57C7738ba8FC1A46A5a1C372C",
+    network: "polygon",
 };
 
 describe("Transfers", () => {


### PR DESCRIPTION
## Summary
- Add `receiver_id`, `address`, and `network` fields to the `Transfer` type
- Make `expires_at`, `commercial_quotation`, and `blindpay_quotation` nullable in `CreateTransferQuoteResponse`
- Make `cover_fees` optional and nullable in `CreateTransferQuoteInput`
- Update test mocks to include the new fields

## Test plan
- [x] TypeScript type check passes (`npm run check-types`)
- [x] All 95 tests pass (`npm test`)