### PR TITLE
Handle empty JSON responses

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,0 +1,17 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { BlindPay } from "./client";
+
+describe("BlindPay client", () => {
+    afterEach(() => fetchMock.resetMocks());
+
+    const blindpay = new BlindPay({ apiKey: "test-key", instanceId: "in_000000000000" });
+
+    it("handles successful empty JSON responses", async () => {
+        fetchMock.mockResponseOnce("", { status: 200 });
+
+        const { data, error } = await blindpay.instances.apiKeys.delete("ak_000000000000");
+
+        expect(error).toBeNull();
+        expect(data).toBeNull();
+    });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -146,7 +146,7 @@ export class BlindPay {
             });
 
             if (!response.ok) {
-                const error = await response.json();
+                const error = await this.parseJsonResponse<{ message?: string }>(response);
                 return {
                     data: null,
                     error: {
@@ -155,10 +155,10 @@ export class BlindPay {
                 };
             }
 
-            const data = await response.json();
+            const data = await this.parseJsonResponse<T>(response);
 
             return {
-                data,
+                data: data as T,
                 error: null,
             };
         } catch (error) {
@@ -186,6 +186,11 @@ export class BlindPay {
                 },
             };
         }
+    }
+
+    private async parseJsonResponse<T>(response: Response): Promise<T | null> {
+        const text = await response.text();
+        return text ? (JSON.parse(text) as T) : null;
     }
 
     private async get<T>(path: string): Promise<BlindpayApiResponse<T>> {


### PR DESCRIPTION
The client currently calls `response.json()` for every successful response, so empty successful responses fail while parsing the body. This can affect endpoints typed as returning `void`, such as delete calls.

This change parses the response body as text first and returns `null` when the body is empty. It also adds a regression test for an empty successful delete response.