### PR TITLE
fix(ci): skip publish when the version is unchanged, and tag releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - name: Setup Bun
@@ -33,11 +32,42 @@ jobs:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Resolve version
+        id: version
+        run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      # This runs on every push to main, so skip an unchanged version instead of
+      # failing the run on "cannot publish over the previously published version".
+      - name: Check whether version is already published
+        id: published
+        run: |
+          if npm view "@blindpay/node@${{ steps.version.outputs.value }}" version >/dev/null 2>&1; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install dependencies
+        if: steps.published.outputs.value == 'false'
         run: bun install --frozen-lockfile
 
       - name: Build package
+        if: steps.published.outputs.value == 'false'
         run: bun run build
 
+      # Auth comes from npm trusted publishing (OIDC), enabled by id-token: write.
+      # Do not add NODE_AUTH_TOKEN: it writes an _authToken into .npmrc, which
+      # takes precedence over the OIDC exchange and fails with E404.
       - name: Publish package
+        if: steps.published.outputs.value == 'false'
         run: npm publish
+
+      - name: Tag and create release
+        if: steps.published.outputs.value == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.version.outputs.value }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+          gh release create "$TAG" --title "$TAG" --generate-notes


### PR DESCRIPTION
## Problem

`publish.yaml` runs on every push to `main` and unconditionally calls `npm publish`, so any merge that does not bump the version fails the run:

```
npm error You cannot publish over the previously published versions: 4.0.2.
```

That just happened twice, on #52 and #58.

The noise is the actual risk here. A permanently red publish job is exactly how `blindpay-cli`'s genuinely broken publish went unnoticed for two and a half months, leaving npm three versions behind while `main` moved on. A job that is always red tells you nothing when it breaks for real.

## Changes

- **Skip when the version is already on the registry.** Same guard already merged into `blindpay-cli` (#19) and `blindpay-mcp` (#9), so the three TypeScript-side repos now behave identically.
- **Tag and create a GitHub release on publish.** This repo has published up to `4.0.2` on npm and has **zero git tags**, so there is no way to tell from the repo alone what shipped in any release.
- **Drop `ref: ${{ github.head_ref }}`**, which is empty on a `push` event.

Authentication is unchanged: this repo already publishes via npm trusted publishing (OIDC), which is why `@blindpay/node@4.0.2` carries SLSA provenance attestations. The comment added above the publish step records why `NODE_AUTH_TOKEN` must not be reintroduced, since adding it is what broke cli.

## Verification

`publish.yaml` parses as valid YAML. The guard logic is identical to the two already merged and verified: both `@blindpay/cli@0.4.0` and `@blindpay/mcp@1.5.0` published successfully through it, with provenance.

## Out of scope, but worth flagging

- `.changeset/` holds roughly 20 accumulated changeset files and **no workflow consumes them**. `main.yaml` only runs lint, typecheck, tests and snyk. So version bumps are in practice manual edits to `package.json`, and the changesets are dead weight. Worth either wiring up `changeset version` or removing changesets.
- `main` currently carries the #52 and #58 fixes at an unbumped `4.0.2`, so both are unreleased. The next version bump ships them.

https://claude.ai/code/session_01F1stiNzuNtJXoXtiW9ZCbs