### PR TITLE
Add customer.* webhook events and customer_id list filters (wave 1)

### DIFF
--- a/.changeset/customer-webhooks-and-list-filters.md
+++ b/.changeset/customer-webhooks-and-list-filters.md
@@ -1,0 +1,7 @@
+---
+"@blindpay/node": minor
+---
+
+Add `customer.new`, `customer.update` and `customer.delete` to `WebhookEvents` (the deployed API has been dual-emitting these alongside the legacy `receiver.*` events since June). Mark the `receiver.*` webhook events `@deprecated` in place; they still fire and are not removed.
+
+Add `customer_id` as an accepted filter on `ListPayinsInput` and `ListPayoutsInput`, matching what the deployed API already accepts. Drop the internal `customer_id`/`customer_name` -> `receiver_id`/`receiver_name` query translation in the `customers` resource's `list()` now that the deployed API accepts the `customer_*` filter names natively.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,8 @@ All types are defined in the same file as the factory function, above it. Naming
 | Create response | `CreatePartnerFeeResponse` |
 | Get input | `GetPayinInput` |
 | Get response | `GetPayinResponse` |
-| Update input | `UpdateReceiverInput` |
-| Delete input | `DeleteReceiverInput` |
+| Update input | `UpdateCustomerInput` |
+| Delete input | `DeleteCustomerInput` |
 | String-only IDs | `export type GetPayinInput = string;` |
 | Object inputs | `export type CreatePayoutInput = { ... };` |
 
@@ -724,18 +724,18 @@ update({ widget_id, ...data }: UpdateWidgetInput): Promise<BlindpayApiResponse<v
 3. **Nested resource IDs**: all IDs come from the input object.
 ```typescript
 export type GetOfframpWalletInput = {
-    receiver_id: string;
+    customer_id: string;
     bank_account_id: string;
     id: string;
 };
 
 get({
-    receiver_id,
+    customer_id,
     bank_account_id,
     id,
 }: GetOfframpWalletInput): Promise<BlindpayApiResponse<GetOfframpWalletResponse>> {
     return client.get(
-        `/instances/${instanceId}/receivers/${receiver_id}/bank-accounts/${bank_account_id}/offramp-wallets/${id}`
+        `/instances/${instanceId}/customers/${customer_id}/bank-accounts/${bank_account_id}/offramp-wallets/${id}`
     );
 },
 ```
@@ -758,7 +758,7 @@ When one endpoint creates different variants based on a `type` field, create sep
 createIndividualWithStandardKYC(
     data: CreateIndividualWithStandardKYCInput
 ): Promise<BlindpayApiResponse<CreateIndividualWithStandardKYCResponse>> {
-    return client.post(`/instances/${instanceId}/receivers`, {
+    return client.post(`/instances/${instanceId}/customers`, {
         kyc_type: "standard",
         type: "individual",
         ...data,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blindpay/node",
-    "version": "4.0.2",
+    "version": "4.1.0",
     "description": "Official Node.js SDK for Blindpay API - Stablecoin API for global payments",
     "keywords": [
         "blindpay",

--- a/src/resources/customers/customers.test.ts
+++ b/src/resources/customers/customers.test.ts
@@ -577,7 +577,7 @@ describe("Customers", () => {
             const mockedLimitIncreaseRequests: GetLimitIncreaseRequestsResponse = [
                 {
                     id: "rl_000000000000",
-                    customer_id: "re_YuaMcI2B8zbQ",
+                    receiver_id: "re_YuaMcI2B8zbQ",
                     status: "in_review",
                     daily: 50000,
                     monthly: 250000,
@@ -589,7 +589,7 @@ describe("Customers", () => {
                 },
                 {
                     id: "rl_000000000000",
-                    customer_id: "re_YuaMcI2B8zbQ",
+                    receiver_id: "re_YuaMcI2B8zbQ",
                     status: "approved",
                     daily: 30000,
                     monthly: 150000,
@@ -618,7 +618,7 @@ describe("Customers", () => {
             const mockedLimitIncreaseRequests: GetLimitIncreaseRequestsResponse = [
                 {
                     id: "rl_000000000000",
-                    customer_id: "re_YuaMcI2B8zbQ",
+                    receiver_id: "re_YuaMcI2B8zbQ",
                     status: "approved",
                     daily: 50000,
                     monthly: 250000,

--- a/src/resources/customers/index.ts
+++ b/src/resources/customers/index.ts
@@ -515,19 +515,7 @@ export type RequestLimitIncreaseResponse = {
 export function createCustomersResource(instanceId: string, client: InternalApiClient) {
     return {
         list(params?: ListCustomersInput): Promise<BlindpayApiResponse<ListCustomersResponse>> {
-            // The API's filter schema still uses receiver_id/receiver_name. Translate
-            // customer_* inputs to the wire-level names so consumers see a clean
-            // customer-only surface. Drop this mapping once the API accepts customer_*.
-            const wireParams = params
-                ? Object.fromEntries(
-                      Object.entries(params).map(([k, v]) => {
-                          if (k === "customer_id") return ["receiver_id", v];
-                          if (k === "customer_name") return ["receiver_name", v];
-                          return [k, v];
-                      })
-                  )
-                : undefined;
-            const queryParams = wireParams ? `?${new URLSearchParams(wireParams)}` : "";
+            const queryParams = params ? `?${new URLSearchParams(params)}` : "";
             return client.get(`/instances/${instanceId}/customers${queryParams}`);
         },
         createIndividualWithStandardKYC(

--- a/src/resources/customers/index.ts
+++ b/src/resources/customers/index.ts
@@ -73,7 +73,7 @@ export type Owner = {
     title: string | null;
     tax_type?: OwnerTaxType | null;
     instance_id?: string;
-    customer_id?: string;
+    receiver_id?: string;
 };
 
 export type IndividualWithStandardKYC = {
@@ -485,7 +485,7 @@ export type LimitIncreaseRequestSupportingDocumentType =
 
 export type GetLimitIncreaseRequestsResponse = Array<{
     id: string;
-    customer_id: string;
+    receiver_id: string;
     status: LimitIncreaseRequestStatus;
     daily: number;
     monthly: number;

--- a/src/resources/payins/index.ts
+++ b/src/resources/payins/index.ts
@@ -99,6 +99,7 @@ export type Payin = {
 export type ListPayinsInput = PaginationParams & {
     status?: TransactionStatus;
     receiver_id?: string;
+    customer_id?: string;
 };
 
 export type ListPayinsResponse =

--- a/src/resources/payouts/index.ts
+++ b/src/resources/payouts/index.ts
@@ -96,6 +96,7 @@ export type Payout = {
 
 export type ListPayoutsInput = PaginationParams & {
     receiver_id?: string;
+    customer_id?: string;
 };
 
 export type ListPayoutsResponse = {

--- a/src/resources/wallets/blockchain.test.ts
+++ b/src/resources/wallets/blockchain.test.ts
@@ -40,7 +40,7 @@ describe("Blockchain wallets", () => {
                     address: "0xDD6a3aD0949396e57C7738ba8FC1A46A5a1C372C",
                     signature_tx_hash: "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
                     is_account_abstraction: false,
-                    customer_id: "re_000000000000",
+                    receiver_id: "re_000000000000",
                 },
             ];
 
@@ -64,7 +64,7 @@ describe("Blockchain wallets", () => {
                 address: "0xDD6a3aD0949396e57C7738ba8FC1A46A5a1C372C",
                 signature_tx_hash: undefined,
                 is_account_abstraction: true,
-                customer_id: "re_000000000000",
+                receiver_id: "re_000000000000",
             };
 
             fetchMock.mockResponseOnce(JSON.stringify(mockedWallet), {
@@ -92,7 +92,7 @@ describe("Blockchain wallets", () => {
                 address: "0xDD6a3aD0949396e57C7738ba8FC1A46A5a1C372C",
                 signature_tx_hash: "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
                 is_account_abstraction: false,
-                customer_id: "re_000000000000",
+                receiver_id: "re_000000000000",
             };
 
             fetchMock.mockResponseOnce(JSON.stringify(mockedWallet), {
@@ -120,7 +120,7 @@ describe("Blockchain wallets", () => {
                 address: "0xDD6a3aD0949396e57C7738ba8FC1A46A5a1C372C",
                 signature_tx_hash: "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
                 is_account_abstraction: false,
-                customer_id: "re_000000000000",
+                receiver_id: "re_000000000000",
             };
 
             fetchMock.mockResponseOnce(JSON.stringify(mockedWallet), {

--- a/src/resources/wallets/blockchain.ts
+++ b/src/resources/wallets/blockchain.ts
@@ -16,7 +16,7 @@ export type ListBlockchainWalletsResponse = Array<{
     address?: string;
     signature_tx_hash?: string;
     is_account_abstraction: boolean;
-    customer_id: string;
+    receiver_id: string;
 }>;
 
 export type CreateBlockchainWalletWithAddressInput = {
@@ -50,7 +50,7 @@ export type GetBlockchainWalletResponse = {
     address?: string;
     signature_tx_hash?: string;
     is_account_abstraction: boolean;
-    customer_id: string;
+    receiver_id: string;
 };
 
 export type CreateBlockchainWalletResponse = {
@@ -60,7 +60,7 @@ export type CreateBlockchainWalletResponse = {
     address?: string;
     signature_tx_hash?: string;
     is_account_abstraction: boolean;
-    customer_id: string;
+    receiver_id: string;
 };
 
 export type CreateAssetTrustlineInput = string;

--- a/src/resources/wallets/offramp.test.ts
+++ b/src/resources/wallets/offramp.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { BlindPay } from "../../client";
+import type { OfframpWallet } from "./offramp";
 
 describe("Offramp wallets", () => {
     afterEach(() => fetchMock.resetMocks());
@@ -8,12 +9,12 @@ describe("Offramp wallets", () => {
 
     describe("List offramp wallets", () => {
         it("should list offramp wallets", async () => {
-            const mockedOfframpWallets = [
+            const mockedOfframpWallets: OfframpWallet[] = [
                 {
                     id: "ow_000000000000",
                     external_id: "your_external_id",
                     instance_id: "in_000000000000",
-                    customer_id: "re_000000000000",
+                    receiver_id: "re_000000000000",
                     bank_account_id: "ba_000000000000",
                     network: "tron",
                     address: "TALJN9zTTEL9TVBb4WuTt6wLvPqJZr3hvb",
@@ -87,11 +88,11 @@ describe("Offramp wallets", () => {
 
     describe("Get offramp wallet", () => {
         it("should get an offramp wallet", async () => {
-            const mockedOfframpWallet = {
+            const mockedOfframpWallet: OfframpWallet = {
                 id: "ow_000000000000",
                 external_id: "your_external_id",
                 instance_id: "in_000000000000",
-                customer_id: "re_000000000000",
+                receiver_id: "re_000000000000",
                 bank_account_id: "ba_000000000000",
                 network: "tron",
                 address: "TALJN9zTTEL9TVBb4WuTt6wLvPqJZr3hvb",

--- a/src/resources/wallets/offramp.ts
+++ b/src/resources/wallets/offramp.ts
@@ -18,7 +18,7 @@ export type OfframpWallet = {
     id: string;
     external_id: string;
     instance_id: string;
-    customer_id: string;
+    receiver_id: string;
     bank_account_id: string;
     network: OfframpWalletNetwork;
     address: string;

--- a/src/resources/webhooks/index.ts
+++ b/src/resources/webhooks/index.ts
@@ -2,8 +2,8 @@ import type { BlindpayApiResponse } from "../../../types";
 import type { InternalApiClient } from "../../internal/api-client";
 
 export type WebhookEvents =
-    | "receiver.new"
-    | "receiver.update"
+    | "receiver.new" // @deprecated use "customer.new" instead
+    | "receiver.update" // @deprecated use "customer.update" instead
     | "bankAccount.new"
     | "payout.new"
     | "payout.update"
@@ -24,7 +24,10 @@ export type WebhookEvents =
     | "transfer.complete"
     | "wallet.new"
     | "wallet.inbound"
-    | "receiver.delete";
+    | "receiver.delete" // @deprecated use "customer.delete" instead
+    | "customer.new"
+    | "customer.update"
+    | "customer.delete";
 
 export type CreateWebhookEndpointInput = {
     url: string;


### PR DESCRIPTION
## What

This is wave 1 of the receivers -> customers migration for blindpay-node: only changes the currently deployed API already accepts. Nothing here requires blindpay-v2 PR #1799 (still open, not deployed) to be merged first.

- `WebhookEvents`: add `customer.new`, `customer.update`, `customer.delete` as new union members. Mark `receiver.new`, `receiver.update`, `receiver.delete` `@deprecated` in place with a trailing comment (a plain string-literal union can't carry per-member JSDoc). The `receiver.*` members are NOT removed, they still fire in production today.
- `ListPayinsInput` / `ListPayoutsInput`: add an optional `customer_id` filter alongside the existing `receiver_id`. `customer_name` is intentionally NOT added to these two, the deployed API does not accept it there.
- `customers` resource `list()`: delete the `customer_id`/`customer_name` -> `receiver_id`/`receiver_name` query-param translation shim. The deployed `GET /v1/instances/{instance_id}/customers` endpoint already accepts `customer_id` and `customer_name` natively, so the translation is now a no-op that was only adding indirection.
- `CLAUDE.md`: fix three stale doc examples (`UpdateReceiverInput`/`DeleteReceiverInput` naming table, an offramp-wallet example still showing `/receivers/{receiver_id}` paths, a create-customer example still POSTing to `/receivers`) that no longer match what the code actually does.

## Also fixes: pre-existing wrong response field names

Independent of the receivers -> customers migration, a previous change had optimistically renamed some response field declarations to `customer_id` ahead of the server. The deployed API still sends `receiver_id` in these places today, so the SDK was declaring a key that never arrives on the wire (Python/Swift hard-fail on this; TypeScript silently resolves to `undefined`). Confirmed each one directly against the deployed `openapi.json` before fixing:

- `ListBlockchainWalletsResponse` / `GetBlockchainWalletResponse` / `CreateBlockchainWalletResponse`: schema `BlockchainWalletOut` has `receiver_id` in `required`, no `customer_id`.
- `OfframpWallet` (used by list/get offramp wallet responses): schema `OfframpWallet` has `receiver_id` in `required`, no `customer_id`.
- `GetLimitIncreaseRequestsResponse`: schema `GetReceiverLimitIncreaseOut` has `receiver_id`, no `customer_id`.
- The nested `Owner` type on `customers.get()` / `customers.list()` for business customers: schema `ReceiverOut.owners[]` nests `receiver_id`, no `customer_id`.

These are safe to land in wave 1 (unlike the wave 2 renames below) because they align the SDK with what production sends **today**, not with the not-yet-deployed rename. Request-side `customer_id` path/body params are untouched, they're correct since routes are already `/customers/...`. `receiver_amount`, `currency_type`, and the bank-accounts owner-id field are untouched too, the latter is a separate pre-existing type-accuracy issue (deployed `BankAccountOut` has neither `receiver_id` nor `customer_id`) left out of scope here.

Test fixtures updated to match, and the offramp wallet fixtures now carry explicit type annotations so a regression of this exact bug fails `check-types`.

## Why this is safe today

I diffed the deployed API's `openapi.json` against this PR's changes before making them:
- `customer.new`/`customer.update`/`customer.delete` are already in the deployed `WebhookEndpointIn.events` enum and the API has been dual-emitting both `receiver.*` and `customer.*` events since June.
- `GET /v1/instances/{instance_id}/payins` and `.../payouts` already list `customer_id` as an accepted query parameter (verified per-endpoint; `customer_name` is only accepted on `.../customers`, not on payins/payouts).
- `GET /v1/instances/{instance_id}/customers` already lists both `customer_id` and `customer_name` as accepted query parameters, alongside the legacy `receiver_id`/`receiver_name`.

Purely additive, purely deprecation-marking, plus the response-field corrections above. No existing consumer's code path changes shape.

## What is deliberately NOT in this PR (wave 2)

The remaining 11 `receiver_*` -> `customer_*` body/response field renames (`customer_local_amount`, `customer_wallet_address`, `customer_network`, `customer_token`, `customer_invite_redirect_url`, `receiver_id` on payin/payout/transfer responses, etc.), the `RECEIVERS_*` -> `CUSTOMERS_*` error-code/message renames, and removal of `receiver.*` from the webhook enum, are all held back on purpose. The deployed API does not accept the renamed field names yet, they only land once blindpay-v2 PR #1799 ships. Shipping those today would break every current SDK user sending `receiver_*` fields.

## Build output

```
$ bun install --frozen-lockfile
Checked 247 installs across 293 packages (no changes)

$ bun run check-types
tsc --noEmit
(no errors)

$ bun run lint:check
Checked 50 files in 31ms. No fixes applied.

$ bun run test
 Test Files  20 passed (20)
      Tests  97 passed (97)
```

## Version

Bumped `package.json` to `4.1.0` (minor, additive) and added a changeset (`.changeset/customer-webhooks-and-list-filters.md`), matching this repo's existing convention (e.g. #54 bumped `package.json` directly alongside its changeset in the same PR). Not bumped again for the field-name fixes added on top, they're covered by the same wave-1 minor bump.

https://claude.ai/code/session_01F1stiNzuNtJXoXtiW9ZCbs
