### PR TITLE
fix(api-sync): fetch delivery artifacts to /tmp, not the repo tree

### DIFF
--- a/.api-sync/delivery.json
+++ b/.api-sync/delivery.json
@@ -1,6 +1,0 @@
-{
-  "source_repository": "blindpaylabs/blindpay-v2",
-  "source_sha": "d86390e2f9f9915598c039c153ec5cab7832ff89",
-  "spec_sha256": "8d41023418c772aa3e4206e357c0963326b2f38336121ad5424d90d666352da9",
-  "generated_at": "2026-08-04T18:01:58Z"
-}

--- a/.github/workflows/api-sync.yml
+++ b/.github/workflows/api-sync.yml
@@ -30,19 +30,19 @@ jobs:
         run: |
           set -e
           git fetch origin api-sync-data
-          mkdir -p .api-sync
+          mkdir -p /tmp/api-sync
 
-          if ! git show origin/api-sync-data:.api-sync/spec-current.json > .api-sync/spec-current.json; then
+          if ! git show origin/api-sync-data:.api-sync/spec-current.json > /tmp/api-sync/spec-current.json; then
             echo "::error::.api-sync/spec-current.json is missing on the api-sync-data branch."
             exit 1
           fi
-          if ! git show origin/api-sync-data:.api-sync/delivery.json > .api-sync/delivery.json; then
+          if ! git show origin/api-sync-data:.api-sync/delivery.json > /tmp/api-sync/delivery.json; then
             echo "::error::.api-sync/delivery.json is missing on the api-sync-data branch."
             exit 1
           fi
 
-          MANIFEST_SHA256=$(jq -r '.spec_sha256' .api-sync/delivery.json)
-          ACTUAL_SHA256=$(sha256sum .api-sync/spec-current.json | cut -d' ' -f1)
+          MANIFEST_SHA256=$(jq -r '.spec_sha256' /tmp/api-sync/delivery.json)
+          ACTUAL_SHA256=$(sha256sum /tmp/api-sync/spec-current.json | cut -d' ' -f1)
           if [ "$MANIFEST_SHA256" != "$ACTUAL_SHA256" ]; then
             echo "::error::spec-current.json sha256 ($ACTUAL_SHA256) does not match delivery.json's spec_sha256 ($MANIFEST_SHA256)."
             exit 1
@@ -54,7 +54,7 @@ jobs:
           fi
 
           echo "Verified spec-current.json (sha256 $ACTUAL_SHA256) against delivery.json:"
-          jq -r '"  source_repository: \(.source_repository)\n  source_sha: \(.source_sha)\n  generated_at: \(.generated_at)"' .api-sync/delivery.json
+          jq -r '"  source_repository: \(.source_repository)\n  source_sha: \(.source_sha)\n  generated_at: \(.generated_at)"' /tmp/api-sync/delivery.json
 
       - name: Check for existing api-sync PR
         id: check-pr
@@ -93,7 +93,7 @@ jobs:
         id: sync
         run: |
           set +e
-          bun scripts/api-sync/index.ts --apply --spec .api-sync/spec-current.json --report /tmp/sync-report.json
+          bun scripts/api-sync/index.ts --apply --spec /tmp/api-sync/spec-current.json --report /tmp/sync-report.json
           echo "exit_code=$?" >> "$GITHUB_OUTPUT"
           set -e
           echo "bump=$(jq -r '.bump' /tmp/sync-report.json)" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ dist
 
 # api-sync: delivered fresh each CI run from the api-sync-data branch, never committed
 .api-sync/spec-current.json
+.api-sync/delivery.json


### PR DESCRIPTION
## Summary
- The api-sync workflow fetched `.api-sync/spec-current.json` and `.api-sync/delivery.json` into the repo tree before running the patcher, so the sync commit's `git add -A` swept `delivery.json` into #72 (merged as part of v5.3.0).
- Biome's formatter check on that committed `delivery.json` then fails lint on main, which blocks the Main workflow (lint gates type-checking, tests and snyk via `needs`).

## Fix
- `.github/workflows/api-sync.yml`: fetch both delivered files to `/tmp/api-sync/` instead of `.api-sync/`, and point the manifest verification and the patcher's `--spec` flag at that path. The committed tree now only ever gains patcher-made source changes plus the refreshed `spec-snapshot.json`.
- Remove the already-committed `.api-sync/delivery.json` from main.
- Add `.api-sync/delivery.json` to `.gitignore` alongside the existing `spec-current.json` entry, as a belt-and-braces guard.

## Test plan
- [x] `bun install`
- [x] `bun run lint:check` passes (only 3 pre-existing warnings, unrelated to this change)
- [x] `bun run sync:check` passes with no pending drift
- [x] `bun run test` has 2 pre-existing failures (`CreateInstanceRfiBody` schema mismatch) that reproduce identically on main without this diff, confirmed unrelated to this fix
- [ ] CI green on this PR

https://claude.ai/code/session_01F1stiNzuNtJXoXtiW9ZCbs