### PR TITLE
fix(api-sync): drop stale spec-map ignore.schemas entries

### DIFF
--- a/.api-sync/spec-map.json
+++ b/.api-sync/spec-map.json
@@ -1759,14 +1759,6 @@
                 "reason": "Webhook payload body for blockchainWallet.new; same reasoning as BankAccountWebhookOut."
             },
             {
-                "name": "CreateInstanceRfiBody",
-                "reason": "Orphan schema, same situation as CreateRfiBody."
-            },
-            {
-                "name": "CreateRfiBody",
-                "reason": "Orphan schema (zero $ref anywhere; the actual POST /rfi request body is inline `{type: object, additionalProperties: {}}`, not $ref'd to this schema). Grouped with the Rfi family since it is a request-body remnant for the unmodeled RFI resource."
-            },
-            {
                 "name": "CustomerDeleteWebhookOut",
                 "reason": "Webhook payload body for customer.delete; same reasoning as BankAccountWebhookOut."
             },
@@ -1781,10 +1773,6 @@
             {
                 "name": "InstanceRfi",
                 "reason": "Instance-level RFI variant; not modeled, same as Rfi."
-            },
-            {
-                "name": "LedgerOperation",
-                "reason": "unreferenced by any public operation"
             },
             {
                 "name": "LimitIncreaseNewWebhookOut",


### PR DESCRIPTION
## Summary
- The v5.3.0 spec refresh (#72) removed `CreateInstanceRfiBody`, `CreateRfiBody`, and `LedgerOperation` from the API spec, but `.api-sync/spec-map.json`'s `ignore.schemas` still listed all three.
- This fails `map.test.ts`'s "every ignore.schemas name exists in the spec's components.schemas" assertion on main, which in turn fails the `tests` job of the Main workflow.

## Fix
- Removed the three stale `ignore.schemas` entries.
- Checked every other entry (including the other Rfi-family ones: `InstanceRfi`, `Rfi`, `RfiField`, `RfiSection`) against the current `.api-sync/spec-snapshot.json` — those all still resolve, so only the three above were stale.
- Also checked `ignore.operations` (the Rfi-family paths and `POST /v1/upload/analyze`) against the current spec — all still present, no changes needed there.

## Test plan
- [x] `bun run test` — 182/182 passing (was 2 failing before this fix)
- [x] `bun run lint:check` — passes (3 pre-existing, unrelated warnings)
- [x] `bun run sync:check` — passes, no pending drift

https://claude.ai/code/session_01F1stiNzuNtJXoXtiW9ZCbs